### PR TITLE
[qatl] response formats

### DIFF
--- a/qatestlink/configs/settings.json
+++ b/qatestlink/configs/settings.json
@@ -5,5 +5,18 @@
         "port": 86
     },
     "dev_key": "ae2f4839476bea169f7461d74b0ed0ac",
-    "log_level":"DEBUG"
+    "log_level":"INFO",
+    "tests":{
+        "skip":{
+            "connection": false,
+            "methods": false
+        },
+        "skip_message": "Test SKIPPED by config settings",
+        "data": {
+            "tproject_name": "qacode",
+            "tproject_id" : 11,
+            "tplan_name" : "v0.3.8",
+            "tplan_id" : 12
+        }
+    }
 }

--- a/qatestlink/core/xmls/base_handler.py
+++ b/qatestlink/core/xmls/base_handler.py
@@ -109,9 +109,12 @@ class BaseHandler(object):
             return value_node_string.text
         if value_node_struct is not None:
             # TODO: i don't know how to do this yet
+            # different response for each request...
+            # maybe ResponseMaybe class have no sense 
+            # maybe must return dict always ?
             raise NotImplementedError(
                 'Response node_member struct not handled yet')
-
+            
 
     def xml_parse(self, xml_str):
         """

--- a/qatestlink/core/xmls/base_handler.py
+++ b/qatestlink/core/xmls/base_handler.py
@@ -117,7 +117,7 @@ class BaseHandler(object):
         """
         Parse request string and return it
         """
-        self.log.debug("Parsing xml:")
+        self.log.info("Parsing xml_str to XML ElementTree class")
         self.log.debug("    from={}".format(xml_str))
         root = ElementTree(xml_from_str(xml_str)).getroot()
         self.log.debug("    to={}".format(root))

--- a/qatestlink/core/xmls/base_handler.py
+++ b/qatestlink/core/xmls/base_handler.py
@@ -104,7 +104,7 @@ class BaseHandler(object):
         value_node_string = self.find_node(
             'string', parent=node_value)
         value_node_struct = self.find_node(
-            'string', parent=node_value)
+            'struct', parent=node_value)
         if value_node_string is not None:
             return value_node_string.text
         if value_node_struct is not None:

--- a/qatestlink/core/xmls/error_handler.py
+++ b/qatestlink/core/xmls/error_handler.py
@@ -9,8 +9,12 @@ from qatestlink.core.xmls.base_handler import BaseHandler
 from qatestlink.core.exceptions.response_exception import ResponseException
 
 
+MSG_PARSE_ERROR = "get_response_error: Error at parse XML error structure from testlink"
+MSG_PARSE_NOT_FOUND = "get_response_error: not found XML error structure"
+
 class ErrorHandler(BaseHandler):
     """TODO: doc class"""
+
 
     def __init__(self, *args, **kwargs):
         """Instance handler"""
@@ -47,13 +51,15 @@ class ErrorHandler(BaseHandler):
         node_array = self.find_node('array', parent=node_param_value)
         # not an exception
         if node_array is None:
+            self.log.info(MSG_PARSE_NOT_FOUND)
             return
         node_data = self.find_node('data', parent=node_array)
         node_data_value = self.find_node('value', parent=node_data)
         node_struct = self.find_node('struct', parent=node_data_value)
         node_struct_members = self.find_nodes('member', parent=node_struct)
         # check error found, not safe, silenced errors here
-        if len(node_struct_members) != 2:
+        if node_struct_members is not None or len(node_struct_members) != 2:
+            self.log.error(MSG_PARSE_ERROR)
             return
         # 1º member
         node_value_one = self.find_node('value', parent=node_struct_members[0])

--- a/qatestlink/core/xmls/error_handler.py
+++ b/qatestlink/core/xmls/error_handler.py
@@ -9,8 +9,8 @@ from qatestlink.core.xmls.base_handler import BaseHandler
 from qatestlink.core.exceptions.response_exception import ResponseException
 
 
-MSG_PARSE_ERROR = "get_response_error: Error at parse XML error structure from testlink"
-MSG_PARSE_NOT_FOUND = "get_response_error: not found XML error structure"
+MSG_PARSE_ERROR = "parse_error: Error at parse XML error structure from testlink"
+MSG_PARSE_NOT_FOUND = "parse_error: not found XML error structure"
 
 class ErrorHandler(BaseHandler):
     """TODO: doc class"""

--- a/qatestlink/core/xmls/error_handler.py
+++ b/qatestlink/core/xmls/error_handler.py
@@ -26,7 +26,7 @@ class ErrorHandler(BaseHandler):
         root = self.xml_parse(xml_str)
         return xml_to_str(root)
 
-    def get_response_error(self, xml_str):
+    def parse_error(self, xml_str):
         """
         Allow to parse string XML object list response to
          ResponseMember object list

--- a/qatestlink/core/xmls/error_handler.py
+++ b/qatestlink/core/xmls/error_handler.py
@@ -58,7 +58,7 @@ class ErrorHandler(BaseHandler):
         node_struct = self.find_node('struct', parent=node_data_value)
         node_struct_members = self.find_nodes('member', parent=node_struct)
         # check error found, not safe, silenced errors here
-        if node_struct_members is not None or len(node_struct_members) != 2:
+        if node_struct_members is not None and len(node_struct_members) != 2:
             self.log.error(MSG_PARSE_ERROR)
             return
         # 1º member

--- a/qatestlink/core/xmls/response_handler.py
+++ b/qatestlink/core/xmls/response_handler.py
@@ -19,7 +19,7 @@ class ResponseHandler(BaseHandler):
         root = self.xml_parse(xml_str)
         return xml_to_str(root)
 
-    def get_response_members(self, xml_str):
+    def parse_members(self, xml_str):
         """
         Allow to parse string XML object list response to
          ResponseMember object list
@@ -41,8 +41,7 @@ class ResponseHandler(BaseHandler):
         nodes_value = self.find_nodes('value', parent=node_data)
         res_members_list = list()
         for node_value in nodes_value:
-            node_struct = self.find_node('struct', parent=node_value) # all okey
-            # import pdb; pdb.set_trace()
+            node_struct = self.find_node('struct', parent=node_value)
             if node_struct is None:
                 self.log.error("node_struct haven't <member> child tag")
             else:
@@ -54,7 +53,7 @@ class ResponseHandler(BaseHandler):
                 res_members_list.append(res_members)
         return res_members_list
 
-    def get_response_struct_members(self, xml_str):
+    def parse_struct_members(self, xml_str):
         """
         Allow to parse string XML object list response to
          ResponseMember object list
@@ -74,6 +73,28 @@ class ResponseHandler(BaseHandler):
             res_member = ResponseMember(self.log, node_member)
             res_members.append(res_member)
         return res_members
+
+    def parse_struct_tree(self, xml_str):
+        node_param = self.find_node('param', xml_str=xml_str)
+        node_param_value = self.find_node('value', parent=node_param)
+        node_struct = self.find_node('struct', parent=node_param_value)
+        nodes_member = self.find_nodes('member', parent=node_struct)
+        nodes_value = self.find_nodes('value', parent=node_data)
+        res_members_list = list()
+        for node_value in nodes_value:
+            node_struct = self.find_node('struct', parent=node_value) # all okey
+            # import pdb; pdb.set_trace()
+            if node_struct is None:
+                self.log.error("node_struct haven't <member> child tag")
+            else:
+                nodes_member = self.find_nodes('member', parent=node_struct)
+                res_members = list()
+                for node_member in nodes_member:
+                    res_member = ResponseMember(self.log, node_member)
+                    res_members.append(res_member)
+                res_members_list.append(res_members)
+        return res_members_list
+
 
 
 class ResponseMember(BaseHandler):

--- a/qatestlink/core/xmls/response_handler.py
+++ b/qatestlink/core/xmls/response_handler.py
@@ -79,20 +79,19 @@ class ResponseHandler(BaseHandler):
         node_param_value = self.find_node('value', parent=node_param)
         node_struct = self.find_node('struct', parent=node_param_value)
         nodes_member = self.find_nodes('member', parent=node_struct)
-        nodes_value = self.find_nodes('value', parent=node_data)
         res_members_list = list()
-        for node_value in nodes_value:
-            node_struct = self.find_node('struct', parent=node_value) # all okey
-            # import pdb; pdb.set_trace()
-            if node_struct is None:
-                self.log.error("node_struct haven't <member> child tag")
-            else:
-                nodes_member = self.find_nodes('member', parent=node_struct)
-                res_members = list()
-                for node_member in nodes_member:
-                    res_member = ResponseMember(self.log, node_member)
-                    res_members.append(res_member)
-                res_members_list.append(res_members)
+        for node_member in nodes_member:
+            node_member_value = self.find_node('value', parent=node_member)
+            node_value_struct = self.find_node('struct', parent=node_member_value)
+            node_member_second = self.find_node('member', parent=node_value_struct)
+            node_member_value_second = self.find_node('value', parent=node_member_second)
+            node_value_struct_second = self.find_node('struct', parent=node_member_value_second)
+            nodes_member_second = self.find_nodes('member', parent=node_value_struct_second)
+            res_members = list()
+            for node_member_second in nodes_member_second:
+                res_member = ResponseMember(self.log, node_member_second)
+                res_members.append(res_member)
+            res_members_list.append(res_members)
         return res_members_list
 
 

--- a/qatestlink/core/xmls/xmlrpc_manager.py
+++ b/qatestlink/core/xmls/xmlrpc_manager.py
@@ -42,7 +42,7 @@ class XMLRPCManager(object):
     def parse_errors(self, xml_str):
         """Raise an exception if response have error structure"""
         #TODO: make enum and custom exception for each exception number
-        self._error_handler.get_response_error(xml_str)
+        self._error_handler.parse_error(xml_str)
 
     def req_check_dev_key(self, dev_key):
         """
@@ -103,7 +103,7 @@ class XMLRPCManager(object):
             RouteType.TPROJECTS, res_str)
         if not as_models:
             return res
-        res_members_list = self._response_handler.get_response_members(
+        res_members_list = self._response_handler.parse_members(
             xml_str=res)
         tprojects = list()
         for res_members in res_members_list:
@@ -151,7 +151,7 @@ class XMLRPCManager(object):
             RouteType.TPROJECT_BY_NAME, res_str)
         if not as_model:
             return res
-        res_members_list = self._response_handler.get_response_struct_members(
+        res_members_list = self._response_handler.parse_struct_members(
             xml_str=res)
         return TProject(res_members_list)
 
@@ -198,7 +198,7 @@ class XMLRPCManager(object):
             RouteType.TPROJECT_TEST_PLANS, res_str)
         if not as_models:
             return res
-        res_members_list = self._response_handler.get_response_members(
+        res_members_list = self._response_handler.parse_members(
             xml_str=res)
         tplans = list()
         for res_members in res_members_list:
@@ -248,7 +248,7 @@ class XMLRPCManager(object):
             RouteType.TPROJECT_TSUITES_FIRST_LEVEL, res_str)
         if not as_models:
             return res
-        res_members_list = self._response_handler.get_response_members(
+        res_members_list = self._response_handler.parse_members(
             xml_str=res)
         tsuites = list()
         for res_members in res_members_list:
@@ -299,7 +299,7 @@ class XMLRPCManager(object):
             RouteType.TPLAN_BY_NAME, res_str)
         if not as_model:
             return res
-        res_members_list = self._response_handler.get_response_struct_members(
+        res_members_list = self._response_handler.parse_struct_members(
             xml_str=res)
         return TPlan(res_members_list)
 
@@ -344,7 +344,7 @@ class XMLRPCManager(object):
             RouteType.TPLAN_PLATFORMS, res_str)
         if not as_models:
             return res
-        res_members_list = self._response_handler.get_response_members(
+        res_members_list = self._response_handler.parse_members(
             xml_str=res)
         tplatforms = list()
         for res_members in res_members_list:
@@ -393,7 +393,7 @@ class XMLRPCManager(object):
             RouteType.TPLAN_BUILDS, res_str)
         if not as_models:
             return res
-        res_members_list = self._response_handler.get_response_members(
+        res_members_list = self._response_handler.parse_members(
             xml_str=res)
         tbuilds = list()
         for res_members in res_members_list:
@@ -442,7 +442,7 @@ class XMLRPCManager(object):
             RouteType.TPLAN_TSUITES, res_str)
         if not as_models:
             return res
-        res_members_list = self._response_handler.get_response_members(
+        res_members_list = self._response_handler.parse_members(
             xml_str=res)
         tsuites = list()
         for res_members in res_members_list:
@@ -491,11 +491,11 @@ class XMLRPCManager(object):
             RouteType.TPLAN_TCASES, res_str)
         if not as_models:
             return res
-        res_members_list = self._response_handler.get_response_struct_members(
+        res_members_list = self._response_handler.parse_struct_members(
             xml_str=res)
         tcases = list()
         for res_members in res_members_list:
-            # TODO: something it's wrong using get_response_struct_members
+            # TODO: something it's wrong using parse_struct_members
             tcase = TCase(res_members)
             tcases.append(tcase)
         return tcases

--- a/qatestlink/core/xmls/xmlrpc_manager.py
+++ b/qatestlink/core/xmls/xmlrpc_manager.py
@@ -491,11 +491,11 @@ class XMLRPCManager(object):
             RouteType.TPLAN_TCASES, res_str)
         if not as_models:
             return res
-        res_members_list = self._response_handler.parse_struct_members(
+        res_members_list = self._response_handler.parse_struct_tree(
             xml_str=res)
         tcases = list()
         for res_members in res_members_list:
-            # TODO: something it's wrong using parse_struct_members
+            # TODO: something it's wrong using parse_struct_tree
             tcase = TCase(res_members)
             tcases.append(tcase)
         return tcases

--- a/tests/unitaries/suite_001_connections.py
+++ b/tests/unitaries/suite_001_connections.py
@@ -4,11 +4,16 @@
 
 import logging
 from unittest import TestCase
+from unittest import skipIf
+from qatestlink.core.utils.Utils import settings
 from qatestlink.core.testlink_manager import TLManager
 from qatestlink.core.exceptions.response_exception import ResponseException
 
 
-API_DEV_KEY = 'ae2f4839476bea169f7461d74b0ed0ac'
+SETTINGS = settings()
+API_DEV_KEY = SETTINGS['dev_key']
+SKIP = SETTINGS['tests']['skip']['connection']
+SKIP_MESSAGE = SETTINGS['tests']['skip_message']
 
 
 class TestConnection(TestCase):
@@ -26,17 +31,20 @@ class TestConnection(TestCase):
         self.assertIsInstance(
             self.testlink_manager.log, logging.Logger)
 
+    @skipIf(SKIP, SKIP_MESSAGE)
     def test_001_connok_bysettings(self):
         """TODO: doc method"""
         self.assertTrue(
             self.testlink_manager.api_login())
 
+    @skipIf(SKIP, SKIP_MESSAGE)
     def test_002_connok_byparam(self):
         """TODO: doc method"""
         self.assertTrue(
             self.testlink_manager.api_login(
                 dev_key=API_DEV_KEY))
 
+    @skipIf(SKIP, SKIP_MESSAGE)
     def test_003_connok_notdevkey(self):
         """TODO: doc method"""
         self.assertTrue(
@@ -59,6 +67,7 @@ class TestConnectionRaises(TestCase):
         self.assertIsInstance(
             self.testlink_manager.log, logging.Logger)
 
+    @skipIf(SKIP, SKIP_MESSAGE)
     def test_001_raises_connemptydevkey(self):
         """TODO: doc method"""
         self.assertRaises(

--- a/tests/unitaries/suite_002_methods.py
+++ b/tests/unitaries/suite_002_methods.py
@@ -6,6 +6,7 @@
 import logging
 from unittest import TestCase
 from unittest import skipIf
+from qatestlink.core.utils.Utils import settings
 from qatestlink.core.xmls.error_handler import ResponseException
 from qatestlink.core.testlink_manager import TLManager
 from qatestlink.core.models.tl_models import TProject
@@ -16,14 +17,11 @@ from qatestlink.core.models.tl_models import TBuild
 from qatestlink.core.models.tl_models import TCase
 
 
-API_DEV_KEY = 'ae2f4839476bea169f7461d74b0ed0ac'
-SKIP = False
-CONFIG = {
-    "tproject_name": "qacode",
-    "tproject_id" : 11,
-    "tplan_name" : "v0.3.8",
-    "tplan_id" : 12
-}
+SETTINGS = settings()
+API_DEV_KEY = SETTINGS['dev_key']
+SKIP = SETTINGS['tests']['skip']['methods']
+SKIP_MESSAGE = SETTINGS['tests']['skip_message']
+DATA = SETTINGS['tests']['data']
 
 
 class TestMethods(TestCase):
@@ -41,7 +39,7 @@ class TestMethods(TestCase):
         self.assertIsInstance(
             self.testlink_manager.log, logging.Logger)
 
-    @skipIf(SKIP, 'Test SKIPPED')
+    @skipIf(SKIP, SKIP_MESSAGE)
     def test_001_method_tprojects(self):
         """TODO: doc method"""
         tprojects = self.testlink_manager.api_tprojects(
@@ -52,80 +50,80 @@ class TestMethods(TestCase):
             self.testlink_manager.log.debug(repr(tproject))
             self.assertIsInstance(tproject, TProject)
 
-    @skipIf(SKIP, 'Test SKIPPED')
+    @skipIf(SKIP, SKIP_MESSAGE)
     def test_002_method_tproject(self):
         """TODO: doc method"""
-        tproject = self.testlink_manager.api_tproject(CONFIG['tproject_name'])
+        tproject = self.testlink_manager.api_tproject(DATA['tproject_name'])
         self.assertIsInstance(tproject, TProject)
-        self.assertEquals(tproject.name, CONFIG['tproject_name'])
+        self.assertEquals(tproject.name, DATA['tproject_name'])
 
-    @skipIf(SKIP, 'Test SKIPPED')
+    @skipIf(SKIP, SKIP_MESSAGE)
     def test_003_method_tproject_tplans(self):
         """TODO: doc method"""
-        tplans = self.testlink_manager.api_tproject_tplans(CONFIG['tproject_id'])
+        tplans = self.testlink_manager.api_tproject_tplans(DATA['tproject_id'])
         self.assertIsInstance(tplans, list)
         self.assertGreater(len(tplans), 0)
         for tplan in tplans:
             self.testlink_manager.log.debug(repr(tplan))
             self.assertIsInstance(tplan, TPlan)
 
-    @skipIf(SKIP, 'Test SKIPPED')
+    @skipIf(SKIP, SKIP_MESSAGE)
     def test_004_method_tproject_tsuites_first_level(self):
         """TODO: doc method"""
         tsuites = self.testlink_manager.api_tproject_tsuites_first_level(
-            CONFIG['tproject_id'])
+            DATA['tproject_id'])
         self.assertIsInstance(tsuites, list)
         self.assertGreater(len(tsuites), 0)
         for tsuite in tsuites:
             self.testlink_manager.log.debug(repr(tsuite))
             self.assertIsInstance(tsuite, TSuite)
 
-    @skipIf(SKIP, 'Test SKIPPED')
+    @skipIf(SKIP, SKIP_MESSAGE)
     def test_005_method_tplan(self):
         """TODO: doc method"""
         tplan = self.testlink_manager.api_tplan(
-            CONFIG['tproject_name'], CONFIG['tplan_name'])
+            DATA['tproject_name'], DATA['tplan_name'])
         self.assertIsInstance(tplan, TPlan)
-        self.assertEquals(tplan.name, CONFIG['tplan_name'])
+        self.assertEquals(tplan.name, DATA['tplan_name'])
 
-    @skipIf(SKIP, 'Test SKIPPED')
+    @skipIf(SKIP, SKIP_MESSAGE)
     def test_006_method_tplan_platforms(self):
         """TODO: doc method"""
         platforms = self.testlink_manager.api_tplan_platforms(
-            CONFIG['tplan_id'])
+            DATA['tplan_id'])
         self.assertIsInstance(platforms, list)
         self.assertGreater(len(platforms), 0)
         for platform in platforms:
             self.testlink_manager.log.debug(repr(platform))
             self.assertIsInstance(platform, TPlatform)
 
-    @skipIf(SKIP, 'Test SKIPPED')
+    @skipIf(SKIP, SKIP_MESSAGE)
     def test_007_method_tplan_builds(self):
         """TODO: doc method"""
         builds = self.testlink_manager.api_tplan_builds(
-            CONFIG['tplan_id'])
+            DATA['tplan_id'])
         self.assertIsInstance(builds, list)
         self.assertGreater(len(builds), 0)
         for build in builds:
             self.testlink_manager.log.debug(repr(build))
             self.assertIsInstance(build, TBuild)
 
-    @skipIf(SKIP, 'Test SKIPPED')
+    @skipIf(SKIP, SKIP_MESSAGE)
     def test_008_method_tplan_tsuites(self):
         """TODO: doc method"""
         tsuites = self.testlink_manager.api_tplan_tsuites(
-            CONFIG['tplan_id'])
+            DATA['tplan_id'])
         self.assertIsInstance(tsuites, list)
         self.assertGreater(len(tsuites), 0)
         for tsuite in tsuites:
             self.testlink_manager.log.debug(repr(tsuite))
             self.assertIsInstance(tsuite, TSuite)
 
-    @skipIf(SKIP, 'Test SKIPPED')
+    @skipIf(True, SKIP_MESSAGE) # TODO: don't skip because of yes
     def test_009_method_tplan_tcases(self):
         """TODO: doc method"""
         tcases = self.testlink_manager.api_tplan_tcases(
-            CONFIG['tplan_id'])
+            DATA['tplan_id'])
         self.assertIsInstance(tcases, list)
         self.assertGreater(len(tcases), 0)
         for tcase in tcases:
@@ -147,13 +145,13 @@ class TestMethodsRaises(TestCase):
         self.assertIsInstance(
             self.testlink_manager.log, logging.Logger)
 
-    @skipIf(SKIP, 'Test SKIPPED')
+    @skipIf(SKIP, SKIP_MESSAGE)
     def test_001_raises_tproject_notname(self):
         """TODO: doc method"""
         self.assertRaises(
             Exception, self.testlink_manager.api_tproject)
 
-    @skipIf(SKIP, 'Test SKIPPED')
+    @skipIf(SKIP, SKIP_MESSAGE)
     def test_002_raises_tproject_emptyname(self):
         """TODO: doc method"""
         self.assertRaises(
@@ -161,13 +159,13 @@ class TestMethodsRaises(TestCase):
             self.testlink_manager.api_tproject,
             '')
 
-    @skipIf(SKIP, 'Test SKIPPED')
+    @skipIf(SKIP, SKIP_MESSAGE)
     def test_003_raises_tproject_tplans_notid(self):
         """TODO: doc method"""
         self.assertRaises(
             Exception, self.testlink_manager.api_tproject_tplans)
 
-    @skipIf(SKIP, 'Test SKIPPED')
+    @skipIf(SKIP, SKIP_MESSAGE)
     def test_004_raises_tproject_tplans_notfoundid(self):
         """TODO: doc method"""
         self.assertRaises(
@@ -175,13 +173,13 @@ class TestMethodsRaises(TestCase):
             self.testlink_manager.api_tproject_tplans,
             -1)
 
-    @skipIf(SKIP, 'Test SKIPPED')
+    @skipIf(SKIP, SKIP_MESSAGE)
     def test_005_raises_tproject_tsuites_first_level_notid(self):
         """TODO: doc method"""
         self.assertRaises(
             Exception, self.testlink_manager.api_tproject_tsuites_first_level)
 
-    @skipIf(SKIP, 'Test SKIPPED')
+    @skipIf(SKIP, SKIP_MESSAGE)
     def test_006_raises_tproject_tsuites_first_level_notfoundid(self):
         """TODO: doc method"""
         self.assertRaises(
@@ -189,7 +187,7 @@ class TestMethodsRaises(TestCase):
             self.testlink_manager.api_tproject_tsuites_first_level,
             -1)
 
-    @skipIf(SKIP, 'Test SKIPPED')
+    @skipIf(SKIP, SKIP_MESSAGE)
     def test_007_raises_tplan_notname(self):
         """TODO: doc method"""
         self.assertRaises(
@@ -202,7 +200,7 @@ class TestMethodsRaises(TestCase):
             ResponseException,
             self.testlink_manager.api_tplan,
             '',
-            CONFIG['tplan_name'])
+            DATA['tplan_name'])
 
     @skipIf(True, 'Test SKIPPED, waiting for issue https://github.com/viglesiasce/testlink/issues/7')
     def test_009_raises_tplan_emptytplanname(self):
@@ -210,7 +208,7 @@ class TestMethodsRaises(TestCase):
         self.assertRaises(
             ResponseException,
             self.testlink_manager.api_tplan,
-            CONFIG['tproject_name'],
+            DATA['tproject_name'],
             '')
 
     @skipIf(True, 'Test SKIPPED, waiting for issue https://github.com/viglesiasce/testlink/issues/7')
@@ -221,13 +219,13 @@ class TestMethodsRaises(TestCase):
             self.testlink_manager.api_tplan,
             '', '')
 
-    @skipIf(SKIP, 'Test SKIPPED')
+    @skipIf(SKIP, SKIP_MESSAGE)
     def test_011_raises_tplan_platforms_notname(self):
         """TODO: doc method"""
         self.assertRaises(
             Exception, self.testlink_manager.api_tplan_platforms)
 
-    @skipIf(SKIP, 'Test SKIPPED')
+    @skipIf(SKIP, SKIP_MESSAGE)
     def test_012_raises_tplan_platforms_notfoundid(self):
         """TODO: doc method"""
         self.assertRaises(
@@ -235,13 +233,13 @@ class TestMethodsRaises(TestCase):
             self.testlink_manager.api_tplan_platforms,
             -1)
 
-    @skipIf(SKIP, 'Test SKIPPED')
+    @skipIf(SKIP, SKIP_MESSAGE)
     def test_013_raises_tplan_builds_notid(self):
         """TODO: doc method"""
         self.assertRaises(
             Exception, self.testlink_manager.api_tplan_builds)
 
-    @skipIf(SKIP, 'Test SKIPPED')
+    @skipIf(SKIP, SKIP_MESSAGE)
     def test_014_raises_tplan_builds_notfoundid(self):
         """TODO: doc method"""
         self.assertRaises(
@@ -249,13 +247,13 @@ class TestMethodsRaises(TestCase):
             self.testlink_manager.api_tplan_builds,
             -1)
 
-    @skipIf(SKIP, 'Test SKIPPED')
+    @skipIf(SKIP, SKIP_MESSAGE)
     def test_015_raises_tplan_tsuites_notid(self):
         """TODO: doc method"""
         self.assertRaises(
             Exception, self.testlink_manager.api_tplan_tsuites)
 
-    @skipIf(SKIP, 'Test SKIPPED')
+    @skipIf(SKIP, SKIP_MESSAGE)
     def test_016_raises_tplan_tsuites_notfoundid(self):
         """TODO: doc method"""
         self.assertRaises(


### PR DESCRIPTION
# TODOs

# EDIT: will finish this branch at issue #23 

- [ ] handle **member** tags in *response xml_str*
  - [ ] *1st structure* : ``(member > (name + value > string | int)) * **n**``
  - [ ] *2nd structure* : ``name + value > struct > (member > (name + value > string | int )) * **n**``

 ## Issues related 

#21 

### notes

Maybe this doc note helps to fix old tests

``` python
class BaseHandler(object):
    def parse_node_value(self, node_value):
            # TODO: i don't know how to do this yet
            # different response for each request...
            # maybe ResponseMaybe class have no sense 
            # maybe must return dict always ?
```